### PR TITLE
Add generate-docker-compose command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,6 +215,15 @@ func main() {
 			Action: generateConfig,
 		},
 		{
+			Name:  "generate-docker-compose",
+			Usage: "Generate a docker-compose file for node deployment",
+			Flags: []cli.Flag{
+				configFileFlag,
+				dockerImageFlag,
+			},
+			Action: generateDockerCompose,
+		},
+		{
 			Name:  "deploy",
 			Usage: "Deploy the Lagrange Node Client with the given config file",
 			Flags: []cli.Flag{
@@ -505,6 +514,16 @@ func generateConfig(c *cli.Context) error {
 	}
 
 	logger.Infof("Client Config file created: %s", configFilePath)
+
+	return nil
+}
+
+func generateDockerCompose(c *cli.Context) error {
+	logger.Infof("Generating Docker Compose file")
+	_, err := utils.GenerateDockerComposeFile(c.String(flagDockerImage), c.String(config.FlagCfg))
+	if err != nil {
+		return fmt.Errorf("failed to generate docker compose file: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Context

An initial attempt at #59 , minimal necessary changes but possibly insufficient for full support of the described workflow.

## Description

This PR implements a new CLI command, `lagrange-cli generate-docker-compose`. The code to generate the docker-compose file is moved into a separate function which the new CLI command calls directly without any usage of `exec.Command("docker", ...)`. This command can therefore be run inside a docker container along with all the other setup commands.

The `deploy` command retains its current behavior of checking for docker image availability, generating the docker-compose file (via the new function), then calling `docker compose -f <file> up -d`. Operators accustomed to the `deploy` workflow do not need to change their behavior.

## Limitations

This change makes the workflow described in #59 possible, but potentially clunky and incomplete. In the output `docker-compose_<net>_<l2>_<key>.yml` file, the volumes are filled in as follows (e.g.):
```
volumes:
      ...
      - /root/.lagrange/keypass:/app/config/keystore/bls.pass
      ...
```
The source path `/root/.lagrange/keypass` is the path *within the CLI container*, but would need to be a path in the *base OS*. Haven't really thought about the best solution here. Hacky solution for now is to pass the file through `sed`:
```
sed "s/\/root\/\.lagrange/\/your\/baseOS\/path\/here/" <docker-compose_<net>_<l2>_<key>.yml >docker-compose-fix_<net>_<l2>_<key>.yml
```
This works for our (Aestus's) use case as we need to pass the docker-compose file through further scripted post-processing anyway (e.g. adding docker network connections) and it's easy to throw a `sed` in there. But it certainly feels like there could be a better solution.